### PR TITLE
Fix OrderHints and SavedOrderHints indexing

### DIFF
--- a/vk_video_decoder/libs/NvVideoParser/include/VulkanAV1Decoder.h
+++ b/vk_video_decoder/libs/NvVideoParser/include/VulkanAV1Decoder.h
@@ -24,6 +24,7 @@
 
 #ifdef ENABLE_AV1_DECODER
 
+#define BUFFER_POOL_MAX_SIZE        10
 #define ALIGN(value, n)         (((value) + (n) - 1) & ~((n) - 1))
 #define CLAMP(value, low, high) ((value) < (low) ? (low) : ((value) > (high) ? (high) : (value)))
 
@@ -286,8 +287,8 @@ typedef struct _av1_ref_frames_s
     bool                    disable_frame_end_update_cdf;
     bool                    segmentation_enabled;
 
-    int8_t                  RefFrameSignBias[8];
-    uint8_t                 ref_order_hint[8];
+    int8_t                  RefFrameSignBias[STD_VIDEO_AV1_NUM_REF_FRAMES];
+    uint8_t                 SavedOrderHints[STD_VIDEO_AV1_NUM_REF_FRAMES];
     uint8_t                 order_hint;
 } av1_ref_frames_s;
 
@@ -346,10 +347,10 @@ protected:
     int32_t                     RefValid[STD_VIDEO_AV1_NUM_REF_FRAMES];
     int32_t                     ref_frame_idx[STD_VIDEO_AV1_REFS_PER_FRAME];
 
-    int32_t                     RefOrderHint[STD_VIDEO_AV1_NUM_REF_FRAMES];
-
-    av1_ref_frames_s            m_pBuffers[STD_VIDEO_AV1_NUM_REF_FRAMES];
-
+    // According to AV1 spec section - E.2. Decoder model definitions
+    int32_t                     RefOrderHint[BUFFER_POOL_MAX_SIZE];
+    av1_ref_frames_s            m_pBuffers[BUFFER_POOL_MAX_SIZE];
+ 
     VkPicIf*                    m_pCurrPic;
 
     bool                        m_bOutputAllLayers;

--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
@@ -322,9 +322,9 @@ bool VulkanAV1Decoder::BeginPicture(VkParserPictureData* pnvpd)
 		av1->dpbSlotInfos[i].flags.segmentation_enabled = m_pBuffers[i].segmentation_enabled;
 		av1->dpbSlotInfos[i].frame_type = m_pBuffers[i].frame_type;
 		av1->dpbSlotInfos[i].OrderHint = m_pBuffers[i].order_hint;
-        for (size_t av1name = 0; av1name < STD_VIDEO_AV1_NUM_REF_FRAMES; av1name += 1) {
-			av1->dpbSlotInfos[i].RefFrameSignBias |= (m_pBuffers[i].RefFrameSignBias[av1name] <= 0) << av1name;
-			av1->dpbSlotInfos[i].SavedOrderHints[av1name] = m_pBuffers[i].ref_order_hint[av1name];
+        for (size_t av1name = STD_VIDEO_AV1_REFERENCE_NAME_LAST_FRAME; av1name < STD_VIDEO_AV1_NUM_REF_FRAMES; av1name += 1) {
+            av1->dpbSlotInfos[i].RefFrameSignBias |= (m_pBuffers[i].RefFrameSignBias[av1name] <= 0) << av1name;
+            av1->dpbSlotInfos[i].SavedOrderHints[av1name] = m_pBuffers[i].SavedOrderHints[av1name];
         }
 	}
 
@@ -382,15 +382,9 @@ void VulkanAV1Decoder::UpdateFramePointers(VkPicIf* currentPicture)
 
             m_pBuffers[ref_index].frame_type = pStd->frame_type;
             m_pBuffers[ref_index].order_hint = pStd->OrderHint;
-            for (uint8_t refName = 0; refName < STD_VIDEO_AV1_REFS_PER_FRAME; refName ++) {
-                uint8_t ref_order_hint = 0;
-                if ((ref_frame_idx[refName] < 8) && (ref_frame_idx[refName] >= 0)) {
-                    ref_order_hint = pStd->OrderHints[refName];
-                } else {
-                    ref_order_hint = pStd->OrderHint;
-                }
-
-                m_pBuffers[ref_index].ref_order_hint[refName] = ref_order_hint;
+            for (uint8_t refName = STD_VIDEO_AV1_REFERENCE_NAME_LAST_FRAME; refName < STD_VIDEO_AV1_NUM_REF_FRAMES; refName ++) {
+                uint8_t ref_order_hint = pStd->OrderHints[refName];
+                m_pBuffers[ref_index].SavedOrderHints[refName] = ref_order_hint;
                 m_pBuffers[ref_index].RefFrameSignBias[refName] = GetRelativeDist(pStd->OrderHint, ref_order_hint);
             }
 
@@ -2082,10 +2076,15 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
             pic_flags->use_ref_frame_mvs = 0;
         }
 
-        for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++)
-        {
-            pStd->OrderHints[i] = RefOrderHint[ref_frame_idx[i]];
-        }
+        // According to AV1 specification: "5.9.2. Uncompressed header syntax"
+        for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
+            // Range check ref_frame_idx, RefOrderHint[] needs to be of size: BUFFER_POOL_MAX_SIZE.
+            if ((ref_frame_idx[i] >= BUFFER_POOL_MAX_SIZE) && (ref_frame_idx[i] < 0)) {
+                assert(false);
+            }
+
+            pStd->OrderHints[i + STD_VIDEO_AV1_REFERENCE_NAME_LAST_FRAME] = RefOrderHint[ref_frame_idx[i]];
+         }
 
         /*      for (int i = 0; i < REFS_PER_FRAME; ++i)
                 {


### PR DESCRIPTION
This change shifts the OrderHints and SavedOrderHints, array values from [0..7] to [1..8]. This is to comply with the wording of the AV1 specification where entry [0] of the OrderHints and SavedOrderHints refer to the current frame itself but are therefore redundant.
This change also resolves a bug where RefOrderHints was accessed outside of the allocated array, this is done by correctly allocating additional space in the array for 10 elements as opposed to the original 8.