### PR TITLE
Fix GOLD frame offset

### DIFF
--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
@@ -1579,7 +1579,7 @@ void VulkanAV1Decoder::SetFrameRefs(int last_frame_idx, int gold_frame_idx)
     }
 
     ref_frame_idx[STD_VIDEO_AV1_REFERENCE_NAME_LAST_FRAME - STD_VIDEO_AV1_REFERENCE_NAME_LAST_FRAME] = last_frame_idx;
-    ref_frame_idx[STD_VIDEO_AV1_REFERENCE_NAME_GOLDEN_FRAME - STD_VIDEO_AV1_REFERENCE_NAME_GOLDEN_FRAME] = gold_frame_idx;
+    ref_frame_idx[STD_VIDEO_AV1_REFERENCE_NAME_GOLDEN_FRAME - STD_VIDEO_AV1_REFERENCE_NAME_LAST_FRAME] = gold_frame_idx;
     usedFrame[last_frame_idx] = 1;
     usedFrame[gold_frame_idx] = 1;
 


### PR DESCRIPTION
The gold frame index was incorrectly being calculated to 0 and was overwriting the current frame offset.
This also means that we have a test hole in the AV1 CTS testing.
An additional test should be added that tests the Gold frame referencing.