### PR TITLE
decoder: Handle AV1 delta_lf_* correctly

### DIFF
--- a/vk_video_decoder/libs/NvVideoParser/include/VulkanAV1Decoder.h
+++ b/vk_video_decoder/libs/NvVideoParser/include/VulkanAV1Decoder.h
@@ -317,8 +317,6 @@ protected:
     uint8_t                     last_intra_only;
 	uint8_t						coded_lossless;
     uint8_t                     all_lossless : 1;
-	uint8_t						delta_lf_present : 1;
-	uint8_t						delta_lf_multi : 1;
 
     // frame header
     uint16_t                    upscaled_width;

--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
@@ -2123,17 +2123,17 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
 
     pStd->delta_q_res = 0;
     pStd->delta_lf_res = 0;
-    delta_lf_present = 0;
-    delta_lf_multi = 0;
+    pic_flags->delta_lf_present = 0;
+    pic_flags->delta_lf_multi = 0;
     pic_flags->delta_q_present = pic_info->quantization.base_q_idx > 0 ? u(1) : 0;
     if (pic_flags->delta_q_present) {
         pStd->delta_q_res = u(2); // 1 << u(2); use log2(). Shift is done at HW
         if (!pic_flags->allow_intrabc) {
-            delta_lf_present = u(1);
+            pic_flags->delta_lf_present = u(1);
         }
-        if (delta_lf_present) {
+        if (pic_flags->delta_lf_present) {
             pStd->delta_lf_res = u(2); //1 << u(2);
-            delta_lf_multi = u(1); // TODO curious not used by the api...
+            pic_flags->delta_lf_multi = u(1);
             // av1_reset_loop_filter_delta(xd, av1_num_planes(cm)); // FIXME
         }
     }


### PR DESCRIPTION
The delta_lf_present and delta_lf_multi syntax elements are parsed but not passed through the Video Std params.