### PR TITLE
VkParserAv1PictureData: increase array size to 256

### DIFF
--- a/vk_video_decoder/include/vkvideo_parser/VulkanVideoParserIf.h
+++ b/vk_video_decoder/include/vkvideo_parser/VulkanVideoParserIf.h
@@ -354,8 +354,8 @@ struct VkParserAv1PictureData {
 	StdVideoAV1LoopRestoration		loopRestoration;
 	StdVideoAV1GlobalMotion			globalMotion;
 	StdVideoAV1FilmGrain			filmGrain;
-	uint32_t						tileOffsets[64]; // TODO: Hack until the interfaces get cleaned up (all the cached parameters should be ref-counted etc, AV1_MAX_COLS*AV1_MAX_ROWS is larger than 64, switch to dynamic structure. Cheat while the CTS uses simpler bitstreams)
-	uint32_t						tileSizes[64];
+	uint32_t						tileOffsets[256]; // TODO: Hack until the interfaces get cleaned up (all the cached parameters should be ref-counted etc, AV1_MAX_COLS*AV1_MAX_ROWS is larger than 256, switch to dynamic structure. Cheat while the CTS uses simpler bitstreams)
+	uint32_t						tileSizes[256];
 	// --- End of pKHR data ---
 
     const StdVideoPictureParametersSet*     pStdSps;

--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
@@ -2271,6 +2271,7 @@ bool VulkanAV1Decoder::ParseObuTileGroup(const AV1ObuHeader& hdr)
 
         m_PicData.tileSizes[m_PicData.khr_info.tileCount] = tileSize;
         m_PicData.khr_info.tileCount++;
+        assert(m_PicData.khr_info.tileCount < 256);  // m_PicData.tileOffsets and tileSizes maximum size is 256.
     }
 
     return (tg_end == num_tiles - 1);


### PR DESCRIPTION
Set to the maximum number of tiles specified
by any defined level.

See VulkanVideoParser.cpp+169

TODO: Use a dynamic allocation of this structure